### PR TITLE
Fix whitespace formatting errors caught by CI

### DIFF
--- a/Logger/Interface/ILogger.cs
+++ b/Logger/Interface/ILogger.cs
@@ -2,5 +2,5 @@ namespace Logger.Interface;
 
 public interface ILogger
 {
-    void WriteInFile<T>(string path, T logData) where T: LogData;
+    void WriteInFile<T>(string path, T logData) where T : LogData;
 }

--- a/Logger/LogData.cs
+++ b/Logger/LogData.cs
@@ -5,16 +5,16 @@ namespace Logger;
 public class LogData
 {
 
-    public string Timestamp { get; set; } 
-    
+    public string Timestamp { get; set; }
+
     public string BackupJobName { get; set; }
-    
+
     public string SourceFilePath { get; set; }
-    
+
     public string TargetFilePath { get; set; }
-    
+
     public long FileSize { get; set; }
-    
+
     public long TransferTimeMs { get; set; }
     public long EncryptionTimeMs { get; set; }
 }

--- a/Logger/Service/DailyLogsService.cs
+++ b/Logger/Service/DailyLogsService.cs
@@ -3,9 +3,9 @@ using Logger.Interface;
 
 namespace Logger.Service;
 
-public class DailyLogsService: ILogger
+public class DailyLogsService : ILogger
 {
-    public void WriteInFile<T>(string path, T logData) where T : LogData 
+    public void WriteInFile<T>(string path, T logData) where T : LogData
     {
         string? directory = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(directory))
@@ -18,9 +18,9 @@ public class DailyLogsService: ILogger
         try
         {
             var options = new JsonSerializerOptions { WriteIndented = true };
-            
+
             string jsonString = JsonSerializer.Serialize(logData, options);
-            
+
             using (StreamWriter outputFile = new StreamWriter(fullPath, append: true))
             {
                 outputFile.WriteLine(jsonString);

--- a/Model/JobRepository.cs
+++ b/Model/JobRepository.cs
@@ -7,7 +7,7 @@ using System.Linq;
 public class JobRepository
 {
     private string PathDest { get; init; }
-    public JobRepository(string pathDest= null)
+    public JobRepository(string pathDest = null)
     {
         if (pathDest == null)
         {
@@ -22,8 +22,8 @@ public class JobRepository
         {
             Directory.CreateDirectory(PathDest);
         }
-    } 
-    
+    }
+
     public bool AddJob(BackupJob job)
     {
         if (job == null) return false;
@@ -39,7 +39,7 @@ public class JobRepository
 
             var jobToSave = GenerateIdIfNeeded(job);
             var fullPath = BuildFilePath(jobToSave);
-            
+
             return WriteJobToFile(jobToSave, fullPath);
         }
         catch
@@ -47,7 +47,7 @@ public class JobRepository
             return false;
         }
     }
-    
+
     private void EnsureDirectoryExists()
     {
         Directory.CreateDirectory(PathDest);
@@ -57,7 +57,7 @@ public class JobRepository
     {
         return Directory.EnumerateFiles(PathDest, "*.json", SearchOption.TopDirectoryOnly).Count();
     }
-    
+
     private bool ExistsById(long id)
     {
         var files = Directory.EnumerateFiles(PathDest, "*.json", SearchOption.TopDirectoryOnly);
@@ -70,7 +70,7 @@ public class JobRepository
         var pattern = $"*_{name}.json";
         return Directory.EnumerateFiles(PathDest, pattern, SearchOption.TopDirectoryOnly).Any();
     }
-    
+
     private BackupJob GenerateIdIfNeeded(BackupJob job)
     {
         if (job.Id != 0) return job;
@@ -81,7 +81,7 @@ public class JobRepository
     {
         return $"{job.Id}_{job.Name}.json";
     }
-    
+
     private string BuildFilePath(BackupJob job)
     {
         return Path.Combine(PathDest, BuildFileName(job));
@@ -94,7 +94,7 @@ public class JobRepository
         File.WriteAllText(fullPath, json);
         return true;
     }
-    
+
     public bool DeleteJob(long id)
     {
         try
@@ -109,7 +109,7 @@ public class JobRepository
             return false;
         }
     }
-    
+
     public bool UpdateJob(BackupJob job)
     {
         if (job == null) return false;
@@ -151,7 +151,7 @@ public class JobRepository
             return false;
         }
     }
-        
+
     public BackupJob GetJobByID(long id)
     {
         try
@@ -166,7 +166,7 @@ public class JobRepository
             return null;
         }
     }
-    
+
     public BackupJob GetJobByName(string Name)
     {
         if (string.IsNullOrWhiteSpace(Name)) return null;
@@ -182,7 +182,7 @@ public class JobRepository
             return null;
         }
     }
-    
+
     public System.Collections.Generic.List<BackupJob> GetAllJobs()
     {
         var result = new System.Collections.Generic.List<BackupJob>();
@@ -210,7 +210,7 @@ public class JobRepository
         }
 
         return result;
-    }  
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- Run `dotnet format` to fix whitespace issues in 4 files flagged by the `format-check` CI job
- Affected files: `Logger/Interface/ILogger.cs`, `Logger/LogData.cs`, `Logger/Service/DailyLogsService.cs`, `Model/JobRepository.cs`

## Test plan
- [ ] Verify `format-check` job passes in CI