### PR TITLE
Fix remaining whitespace error in JobRepository

### DIFF
--- a/Model/JobRepository.cs
+++ b/Model/JobRepository.cs
@@ -1,4 +1,5 @@
 ﻿namespace Model;
+
 using System;
 using System.IO;
 using System.Text.Json;


### PR DESCRIPTION
## Summary
- Add missing blank line after namespace declaration in `Model/JobRepository.cs`
- Fixes the last `format-check` CI failure after PR #4

## Test plan
- [x] Verify `format-check` job passes in CI