### PR TITLE
feat: remove 5-job limit (#10)

### DIFF
--- a/Application/Services/JobManagementService.cs
+++ b/Application/Services/JobManagementService.cs
@@ -5,7 +5,6 @@ namespace Application.Services;
 
 public class JobManagementService
 {
-    private const int MaxJobs = 5;
     private readonly IJobRepository _repository;
     private readonly BackupDomainService _domainService;
 
@@ -17,8 +16,6 @@ public class JobManagementService
 
     public BackupJob CreateJob(string name, string source, string target, BackupType type)
     {
-        _domainService.ValidateJobLimit(_repository.Count(), MaxJobs);
-
         var job = new BackupJob(0, name, source, target, type);
         job.Validate();
         _repository.Save(job);

--- a/Application/Services/JobManagementService.cs
+++ b/Application/Services/JobManagementService.cs
@@ -6,12 +6,10 @@ namespace Application.Services;
 public class JobManagementService
 {
     private readonly IJobRepository _repository;
-    private readonly BackupDomainService _domainService;
 
-    public JobManagementService(IJobRepository repository, BackupDomainService domainService)
+    public JobManagementService(IJobRepository repository)
     {
         _repository = repository;
-        _domainService = domainService;
     }
 
     public BackupJob CreateJob(string name, string source, string target, BackupType type)

--- a/Console/Program.cs
+++ b/Console/Program.cs
@@ -46,7 +46,7 @@ public class Program
         var backupExecutor = new BackupExecutor(
             fileSystem, pathAdapter, eventBus, domainService, tracker);
         var strategyFactory = new BackupStrategyFactory();
-        var jobService = new JobManagementService(jobRepository, domainService);
+        var jobService = new JobManagementService(jobRepository);
         var executionService = new BackupExecutionService(
             jobRepository, backupExecutor, strategyFactory);
 

--- a/Document/ClassDiagram.puml
+++ b/Document/ClassDiagram.puml
@@ -607,8 +607,8 @@ end note
 
 note right of BackupDomainService
   **Stateless Domain Service**.
-  ValidateJobLimit() enforces MAX_JOBS rule
-  (configurable, not hardcoded in entity).
+  ValidateJobLimit() retained but unused since v2.0
+  (job limit removed per FR-02).
   Orchestrates strategy-based file selection.
 end note
 

--- a/Model/Services/BackupDomainService.cs
+++ b/Model/Services/BackupDomainService.cs
@@ -2,6 +2,7 @@ namespace Model;
 
 public class BackupDomainService
 {
+    [Obsolete("Job limit removed in v2.0 (FR-02, issue #10). Retained per PRD decision.")]
     public void ValidateJobLimit(int currentCount, int maxJobs)
     {
         if (currentCount >= maxJobs)

--- a/Test/ApplicationTest/JobManagementServiceTests.cs
+++ b/Test/ApplicationTest/JobManagementServiceTests.cs
@@ -8,14 +8,12 @@ namespace ApplicationTest;
 public class JobManagementServiceTests
 {
     private readonly Mock<IJobRepository> _mockRepo;
-    private readonly BackupDomainService _domainService;
     private readonly JobManagementService _service;
 
     public JobManagementServiceTests()
     {
         _mockRepo = new Mock<IJobRepository>();
-        _domainService = new BackupDomainService();
-        _service = new JobManagementService(_mockRepo.Object, _domainService);
+        _service = new JobManagementService(_mockRepo.Object);
     }
 
     [Fact]
@@ -25,14 +23,6 @@ public class JobManagementServiceTests
 
         Assert.Equal("TestJob", job.Name);
         _mockRepo.Verify(r => r.Save(It.Is<BackupJob>(j => j.Name == "TestJob")), Times.Once);
-    }
-
-    [Fact]
-    public void CreateJob_SixthJob_ShouldSucceed()
-    {
-        var job = _service.CreateJob("Job6", "/src", "/dst", BackupType.Full);
-
-        Assert.Equal("Job6", job.Name);
     }
 
     [Fact]

--- a/Test/ApplicationTest/JobManagementServiceTests.cs
+++ b/Test/ApplicationTest/JobManagementServiceTests.cs
@@ -30,15 +30,6 @@ public class JobManagementServiceTests
     }
 
     [Fact]
-    public void CreateJob_AtMaxJobs_ShouldThrow()
-    {
-        _mockRepo.Setup(r => r.Count()).Returns(5);
-
-        Assert.Throws<JobLimitExceededException>(
-            () => _service.CreateJob("TestJob", "/src", "/dst", BackupType.Full));
-    }
-
-    [Fact]
     public void CreateJob_SixthJob_ShouldSucceed()
     {
         _mockRepo.Setup(r => r.Count()).Returns(5);

--- a/Test/ApplicationTest/JobManagementServiceTests.cs
+++ b/Test/ApplicationTest/JobManagementServiceTests.cs
@@ -33,6 +33,8 @@ public class JobManagementServiceTests
             var job = _service.CreateJob($"Job{i + 1}", "/src", "/dst", BackupType.Full);
             Assert.Equal($"Job{i + 1}", job.Name);
         }
+
+        _mockRepo.Verify(r => r.Save(It.IsAny<BackupJob>()), Times.Exactly(10));
     }
 
     [Fact]

--- a/Test/ApplicationTest/JobManagementServiceTests.cs
+++ b/Test/ApplicationTest/JobManagementServiceTests.cs
@@ -39,6 +39,27 @@ public class JobManagementServiceTests
     }
 
     [Fact]
+    public void CreateJob_SixthJob_ShouldSucceed()
+    {
+        _mockRepo.Setup(r => r.Count()).Returns(5);
+
+        var job = _service.CreateJob("Job6", "/src", "/dst", BackupType.Full);
+
+        Assert.Equal("Job6", job.Name);
+    }
+
+    [Fact]
+    public void CreateJob_TenJobs_ShouldAllSucceed()
+    {
+        for (int i = 0; i < 10; i++)
+        {
+            _mockRepo.Setup(r => r.Count()).Returns(i);
+            var job = _service.CreateJob($"Job{i + 1}", "/src", "/dst", BackupType.Full);
+            Assert.Equal($"Job{i + 1}", job.Name);
+        }
+    }
+
+    [Fact]
     public void CreateJob_InvalidName_ShouldThrow()
     {
         _mockRepo.Setup(r => r.Count()).Returns(0);

--- a/Test/ApplicationTest/JobManagementServiceTests.cs
+++ b/Test/ApplicationTest/JobManagementServiceTests.cs
@@ -21,8 +21,6 @@ public class JobManagementServiceTests
     [Fact]
     public void CreateJob_ShouldValidateAndSave()
     {
-        _mockRepo.Setup(r => r.Count()).Returns(0);
-
         var job = _service.CreateJob("TestJob", "/src", "/dst", BackupType.Full);
 
         Assert.Equal("TestJob", job.Name);
@@ -32,8 +30,6 @@ public class JobManagementServiceTests
     [Fact]
     public void CreateJob_SixthJob_ShouldSucceed()
     {
-        _mockRepo.Setup(r => r.Count()).Returns(5);
-
         var job = _service.CreateJob("Job6", "/src", "/dst", BackupType.Full);
 
         Assert.Equal("Job6", job.Name);
@@ -44,7 +40,6 @@ public class JobManagementServiceTests
     {
         for (int i = 0; i < 10; i++)
         {
-            _mockRepo.Setup(r => r.Count()).Returns(i);
             var job = _service.CreateJob($"Job{i + 1}", "/src", "/dst", BackupType.Full);
             Assert.Equal($"Job{i + 1}", job.Name);
         }
@@ -53,8 +48,6 @@ public class JobManagementServiceTests
     [Fact]
     public void CreateJob_InvalidName_ShouldThrow()
     {
-        _mockRepo.Setup(r => r.Count()).Returns(0);
-
         Assert.Throws<InvalidBackupJobException>(
             () => _service.CreateJob("", "/src", "/dst", BackupType.Full));
     }

--- a/Test/ConsoleTest/ConsoleIntegrationTests.cs
+++ b/Test/ConsoleTest/ConsoleIntegrationTests.cs
@@ -22,7 +22,6 @@ public class ConsoleIntegrationTests
     public void FullFlow_CreateAndListJob_ShouldShowCreatedJob()
     {
         var mockRepo = new Mock<IJobRepository>();
-        mockRepo.Setup(r => r.Count()).Returns(0);
         var createdJobs = new List<BackupJob>();
         mockRepo.Setup(r => r.Save(It.IsAny<BackupJob>()))
             .Callback<BackupJob>(j => { j.Id = 1; createdJobs.Add(j); });

--- a/Test/ConsoleTest/ConsoleIntegrationTests.cs
+++ b/Test/ConsoleTest/ConsoleIntegrationTests.cs
@@ -27,8 +27,7 @@ public class ConsoleIntegrationTests
             .Callback<BackupJob>(j => { j.Id = 1; createdJobs.Add(j); });
         mockRepo.Setup(r => r.GetAll()).Returns(() => new List<BackupJob>(createdJobs));
 
-        var domainService = new BackupDomainService();
-        var jobService = new JobManagementService(mockRepo.Object, domainService);
+        var jobService = new JobManagementService(mockRepo.Object);
 
         var mockConfig = new Mock<ILanguageConfig>();
         mockConfig.Setup(c => c.GetLanguage()).Returns(Language.EN);
@@ -59,8 +58,7 @@ public class ConsoleIntegrationTests
     public void FullFlow_DeleteJob_ShouldCallRepositoryDelete()
     {
         var mockRepo = new Mock<IJobRepository>();
-        var domainService = new BackupDomainService();
-        var jobService = new JobManagementService(mockRepo.Object, domainService);
+        var jobService = new JobManagementService(mockRepo.Object);
 
         var mockConfig = new Mock<ILanguageConfig>();
         mockConfig.Setup(c => c.GetLanguage()).Returns(Language.EN);
@@ -89,8 +87,7 @@ public class ConsoleIntegrationTests
         var existingJob = new BackupJob(1, "OldName", "/old/src", "/old/dst", BackupType.Full);
         mockRepo.Setup(r => r.GetById(1)).Returns(existingJob);
 
-        var domainService = new BackupDomainService();
-        var jobService = new JobManagementService(mockRepo.Object, domainService);
+        var jobService = new JobManagementService(mockRepo.Object);
 
         var mockConfig = new Mock<ILanguageConfig>();
         mockConfig.Setup(c => c.GetLanguage()).Returns(Language.EN);

--- a/Test/ConsoleTest/CreateJobCommandTests.cs
+++ b/Test/ConsoleTest/CreateJobCommandTests.cs
@@ -41,17 +41,6 @@ public class CreateJobCommandTests
     }
 
     [Fact]
-    public void Execute_AtJobLimit_ShouldReturnFailure()
-    {
-        _mockRepo.Setup(r => r.Count()).Returns(5);
-        var args = new List<string> { "MyBackup", "/src", "/dst", "Full" };
-
-        var result = _command.Execute(args);
-
-        Assert.False(result.IsSuccess());
-    }
-
-    [Fact]
     public void Execute_WithEmptyName_ShouldReturnFailure()
     {
         var args = new List<string> { "", "/src", "/dst", "Full" };

--- a/Test/ConsoleTest/CreateJobCommandTests.cs
+++ b/Test/ConsoleTest/CreateJobCommandTests.cs
@@ -14,7 +14,6 @@ public class CreateJobCommandTests
     public CreateJobCommandTests()
     {
         _mockRepo = new Mock<IJobRepository>();
-        _mockRepo.Setup(r => r.Count()).Returns(0);
         var domainService = new BackupDomainService();
         var jobService = new JobManagementService(_mockRepo.Object, domainService);
         _command = new CreateJobCommand(jobService, TextWriter.Null);

--- a/Test/ConsoleTest/CreateJobCommandTests.cs
+++ b/Test/ConsoleTest/CreateJobCommandTests.cs
@@ -14,8 +14,7 @@ public class CreateJobCommandTests
     public CreateJobCommandTests()
     {
         _mockRepo = new Mock<IJobRepository>();
-        var domainService = new BackupDomainService();
-        var jobService = new JobManagementService(_mockRepo.Object, domainService);
+        var jobService = new JobManagementService(_mockRepo.Object);
         _command = new CreateJobCommand(jobService, TextWriter.Null);
     }
 

--- a/Test/ConsoleTest/DeleteJobCommandTests.cs
+++ b/Test/ConsoleTest/DeleteJobCommandTests.cs
@@ -14,8 +14,7 @@ public class DeleteJobCommandTests
     public DeleteJobCommandTests()
     {
         _mockRepo = new Mock<IJobRepository>();
-        var domainService = new BackupDomainService();
-        var jobService = new JobManagementService(_mockRepo.Object, domainService);
+        var jobService = new JobManagementService(_mockRepo.Object);
         _command = new DeleteJobCommand(jobService, TextWriter.Null);
     }
 

--- a/Test/ConsoleTest/ListJobsCommandTests.cs
+++ b/Test/ConsoleTest/ListJobsCommandTests.cs
@@ -14,8 +14,7 @@ public class ListJobsCommandTests
     public ListJobsCommandTests()
     {
         _mockRepo = new Mock<IJobRepository>();
-        var domainService = new BackupDomainService();
-        _jobService = new JobManagementService(_mockRepo.Object, domainService);
+        _jobService = new JobManagementService(_mockRepo.Object);
     }
 
     [Fact]

--- a/Test/ConsoleTest/ModifyJobCommandTests.cs
+++ b/Test/ConsoleTest/ModifyJobCommandTests.cs
@@ -14,8 +14,7 @@ public class ModifyJobCommandTests
     public ModifyJobCommandTests()
     {
         _mockRepo = new Mock<IJobRepository>();
-        var domainService = new BackupDomainService();
-        var jobService = new JobManagementService(_mockRepo.Object, domainService);
+        var jobService = new JobManagementService(_mockRepo.Object);
         _command = new ModifyJobCommand(jobService, TextWriter.Null);
     }
 

--- a/Test/ModelTest/BackupDomainServiceTests.cs
+++ b/Test/ModelTest/BackupDomainServiceTests.cs
@@ -2,6 +2,7 @@ using Model;
 
 namespace ModelTest;
 
+#pragma warning disable CS0618 // ValidateJobLimit is intentionally tested despite [Obsolete]
 public class BackupDomainServiceTests
 {
     private readonly BackupDomainService _service = new();


### PR DESCRIPTION
## Summary
- Remove the 5-job limit from `JobManagementService.CreateJob()` (FR-02)
- `ValidateJobLimit()` and `JobLimitExceededException` are kept in the codebase per FR-02.3
- Clean up stale `Count()` mock setups across test files

## Test plan
- [x] 2 new tests: `CreateJob_SixthJob_ShouldSucceed`, `CreateJob_TenJobs_ShouldAllSucceed`
- [x] 2 obsolete tests removed: `CreateJob_AtMaxJobs_ShouldThrow`, `Execute_AtJobLimit_ShouldReturnFailure`
- [x] Full suite: 271 tests, 0 failures

Closes #10