### PR TITLE
feat: add EncryptionTimeMs to TransferLog (#11)

### DIFF
--- a/Application/DTOs/TransferLog.cs
+++ b/Application/DTOs/TransferLog.cs
@@ -8,4 +8,5 @@ public record TransferLog
     public string DestPath { get; init; } = string.Empty;
     public long FileSize { get; init; }
     public long TransferTimeMs { get; init; }
+    public long EncryptionTimeMs { get; init; }
 }

--- a/Test/InfrastructureTest/JsonTransferLoggerTests.cs
+++ b/Test/InfrastructureTest/JsonTransferLoggerTests.cs
@@ -131,7 +131,7 @@ public class JsonTransferLoggerTests : IDisposable
         Assert.Equal(2, doc.RootElement.GetArrayLength());
 
         var expectedFields = new HashSet<string>
-            { "Timestamp", "BackupName", "SourcePath", "DestPath", "FileSize", "TransferTimeMs" };
+            { "Timestamp", "BackupName", "SourcePath", "DestPath", "FileSize", "TransferTimeMs", "EncryptionTimeMs" };
         var first = doc.RootElement[0];
         var actualFields = first.EnumerateObject().Select(p => p.Name).ToHashSet();
         Assert.True(expectedFields.SetEquals(actualFields));

--- a/Test/InfrastructureTest/TransferLogSerializationTests.cs
+++ b/Test/InfrastructureTest/TransferLogSerializationTests.cs
@@ -51,7 +51,7 @@ public class TransferLogSerializationTests
     }
 
     [Fact]
-    public void TransferLog_SerializedJson_HasExactly6SpecFields()
+    public void TransferLog_SerializedJson_HasExactly7SpecFields()
     {
         var log = new TransferLog
         {
@@ -60,20 +60,22 @@ public class TransferLogSerializationTests
             SourcePath = "\\\\PC\\D$\\Photos\\chat.jpg",
             DestPath = "\\\\PC\\E$\\Backup\\chat.jpg",
             FileSize = 2048576,
-            TransferTimeMs = 150
+            TransferTimeMs = 150,
+            EncryptionTimeMs = 0
         };
 
         var json = JsonSerializer.Serialize(log);
         using var doc = JsonDocument.Parse(json);
         var propertyNames = doc.RootElement.EnumerateObject().Select(p => p.Name).ToList();
 
-        Assert.Equal(6, propertyNames.Count);
+        Assert.Equal(7, propertyNames.Count);
         Assert.Contains("Timestamp", propertyNames);
         Assert.Contains("BackupName", propertyNames);
         Assert.Contains("SourcePath", propertyNames);
         Assert.Contains("DestPath", propertyNames);
         Assert.Contains("FileSize", propertyNames);
         Assert.Contains("TransferTimeMs", propertyNames);
+        Assert.Contains("EncryptionTimeMs", propertyNames);
     }
 
     [Fact]
@@ -86,7 +88,8 @@ public class TransferLogSerializationTests
             SourcePath = "\\\\PC\\D$\\Photos\\chat.jpg",
             DestPath = "\\\\PC\\E$\\Backup\\Photos\\chat.jpg",
             FileSize = 2048576,
-            TransferTimeMs = 150
+            TransferTimeMs = 150,
+            EncryptionTimeMs = 250
         };
 
         var json = JsonSerializer.Serialize(original);
@@ -99,5 +102,47 @@ public class TransferLogSerializationTests
         Assert.Equal(original.DestPath, restored.DestPath);
         Assert.Equal(original.FileSize, restored.FileSize);
         Assert.Equal(original.TransferTimeMs, restored.TransferTimeMs);
+        Assert.Equal(original.EncryptionTimeMs, restored.EncryptionTimeMs);
+    }
+
+    [Fact]
+    public void TransferLog_V1Log_DeserializesWithDefaultEncryptionTimeMs()
+    {
+        var json = """
+        {
+            "Timestamp": "2024-01-26T14:30:00",
+            "BackupName": "OldBackup",
+            "SourcePath": "\\\\PC\\src",
+            "DestPath": "\\\\PC\\dst",
+            "FileSize": 1024,
+            "TransferTimeMs": 50
+        }
+        """;
+
+        var log = JsonSerializer.Deserialize<TransferLog>(json);
+
+        Assert.NotNull(log);
+        Assert.Equal(0, log.EncryptionTimeMs);
+    }
+
+    [Fact]
+    public void TransferLog_EncryptionTimeMs_RoundTrip_PreservesNonZeroValue()
+    {
+        var original = new TransferLog
+        {
+            Timestamp = new DateTime(2024, 6, 15, 10, 0, 0),
+            BackupName = "Encrypted Backup",
+            SourcePath = "\\\\PC\\D$\\secret.docx",
+            DestPath = "\\\\PC\\E$\\Backup\\secret.docx",
+            FileSize = 4096,
+            TransferTimeMs = 200,
+            EncryptionTimeMs = 500
+        };
+
+        var json = JsonSerializer.Serialize(original);
+        var restored = JsonSerializer.Deserialize<TransferLog>(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal(500, restored.EncryptionTimeMs);
     }
 }

--- a/Test/InfrastructureTest/TransferLogSerializationTests.cs
+++ b/Test/InfrastructureTest/TransferLogSerializationTests.cs
@@ -145,4 +145,25 @@ public class TransferLogSerializationTests
         Assert.NotNull(restored);
         Assert.Equal(500, restored.EncryptionTimeMs);
     }
+
+    [Fact]
+    public void TransferLog_NegativeEncryptionTimeMs_RoundTrip_PreservesErrorCode()
+    {
+        var original = new TransferLog
+        {
+            Timestamp = new DateTime(2024, 6, 15, 10, 0, 0),
+            BackupName = "Failed Encryption",
+            SourcePath = "\\\\PC\\D$\\secret.docx",
+            DestPath = "\\\\PC\\E$\\Backup\\secret.docx",
+            FileSize = 4096,
+            TransferTimeMs = 200,
+            EncryptionTimeMs = -1
+        };
+
+        var json = JsonSerializer.Serialize(original);
+        var restored = JsonSerializer.Deserialize<TransferLog>(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal(-1, restored.EncryptionTimeMs);
+    }
 }

--- a/Test/InfrastructureTest/XmlTransferLoggerTests.cs
+++ b/Test/InfrastructureTest/XmlTransferLoggerTests.cs
@@ -73,4 +73,36 @@ public class XmlTransferLoggerTests : IDisposable
         Assert.Contains("XmlJob1", content);
         Assert.Contains("XmlJob2", content);
     }
+
+    [Fact]
+    public void LogTransfer_ShouldSerializeAllEncryptionTimeMsSemanticsInXml()
+    {
+        var easyLogger = new DailyLogsService();
+        ITransferLogger logger = new XmlTransferLogger(_testDir, easyLogger);
+
+        logger.LogTransfer(new TransferLog
+        {
+            Timestamp = DateTime.Now, BackupName = "NotEncrypted",
+            SourcePath = "/src/a.txt", DestPath = "/dst/a.txt",
+            FileSize = 1024, TransferTimeMs = 50, EncryptionTimeMs = 0
+        });
+        logger.LogTransfer(new TransferLog
+        {
+            Timestamp = DateTime.Now, BackupName = "Encrypted",
+            SourcePath = "/src/b.txt", DestPath = "/dst/b.txt",
+            FileSize = 2048, TransferTimeMs = 100, EncryptionTimeMs = 350
+        });
+        logger.LogTransfer(new TransferLog
+        {
+            Timestamp = DateTime.Now, BackupName = "EncryptionFailed",
+            SourcePath = "/src/c.txt", DestPath = "/dst/c.txt",
+            FileSize = 4096, TransferTimeMs = 200, EncryptionTimeMs = -1
+        });
+
+        var expectedFile = Path.Combine(_testDir, $"{DateTime.Now:yyyy-MM-dd}.xml");
+        var content = File.ReadAllText(expectedFile);
+        Assert.Contains("<EncryptionTimeMs>0</EncryptionTimeMs>", content);
+        Assert.Contains("<EncryptionTimeMs>350</EncryptionTimeMs>", content);
+        Assert.Contains("<EncryptionTimeMs>-1</EncryptionTimeMs>", content);
+    }
 }

--- a/Test/InfrastructureTest/XmlTransferLoggerTests.cs
+++ b/Test/InfrastructureTest/XmlTransferLoggerTests.cs
@@ -82,21 +82,33 @@ public class XmlTransferLoggerTests : IDisposable
 
         logger.LogTransfer(new TransferLog
         {
-            Timestamp = DateTime.Now, BackupName = "NotEncrypted",
-            SourcePath = "/src/a.txt", DestPath = "/dst/a.txt",
-            FileSize = 1024, TransferTimeMs = 50, EncryptionTimeMs = 0
+            Timestamp = DateTime.Now,
+            BackupName = "NotEncrypted",
+            SourcePath = "/src/a.txt",
+            DestPath = "/dst/a.txt",
+            FileSize = 1024,
+            TransferTimeMs = 50,
+            EncryptionTimeMs = 0
         });
         logger.LogTransfer(new TransferLog
         {
-            Timestamp = DateTime.Now, BackupName = "Encrypted",
-            SourcePath = "/src/b.txt", DestPath = "/dst/b.txt",
-            FileSize = 2048, TransferTimeMs = 100, EncryptionTimeMs = 350
+            Timestamp = DateTime.Now,
+            BackupName = "Encrypted",
+            SourcePath = "/src/b.txt",
+            DestPath = "/dst/b.txt",
+            FileSize = 2048,
+            TransferTimeMs = 100,
+            EncryptionTimeMs = 350
         });
         logger.LogTransfer(new TransferLog
         {
-            Timestamp = DateTime.Now, BackupName = "EncryptionFailed",
-            SourcePath = "/src/c.txt", DestPath = "/dst/c.txt",
-            FileSize = 4096, TransferTimeMs = 200, EncryptionTimeMs = -1
+            Timestamp = DateTime.Now,
+            BackupName = "EncryptionFailed",
+            SourcePath = "/src/c.txt",
+            DestPath = "/dst/c.txt",
+            FileSize = 4096,
+            TransferTimeMs = 200,
+            EncryptionTimeMs = -1
         });
 
         var expectedFile = Path.Combine(_testDir, $"{DateTime.Now:yyyy-MM-dd}.xml");

--- a/Test/InfrastructureTest/XmlTransferLoggerTests.cs
+++ b/Test/InfrastructureTest/XmlTransferLoggerTests.cs
@@ -56,6 +56,7 @@ public class XmlTransferLoggerTests : IDisposable
         Assert.Contains("XmlBackup", content);
         Assert.Contains("2048", content);
         Assert.Contains("<TransferLog", content);
+        Assert.Contains("<EncryptionTimeMs>0</EncryptionTimeMs>", content);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add `EncryptionTimeMs` property (`long`, default `0`) to `TransferLog` record for v2.0 log spec (7 fields)
- Semantics: `0` = not encrypted, `> 0` = encryption time in ms, `< 0` = encryption error code
- Backward compatible: v1.0 logs (6 fields) deserialize with `EncryptionTimeMs = 0`

## Changes
| File | Change |
|------|--------|
| `Application/DTOs/TransferLog.cs` | Add `EncryptionTimeMs` property |
| `Test/InfrastructureTest/TransferLogSerializationTests.cs` | Update field count 6→7, add v1.0 compat test, positive & negative round-trip tests |
| `Test/InfrastructureTest/JsonTransferLoggerTests.cs` | Update expectedFields HashSet to 7 fields |
| `Test/InfrastructureTest/XmlTransferLoggerTests.cs` | Assert `<EncryptionTimeMs>` in XML output |

## Test plan
- [x] 280 tests pass (0 failures)
- [x] JSON serialization produces exactly 7 fields
- [x] v1.0 log (6 fields) deserializes with EncryptionTimeMs = 0
- [x] Positive value (500) round-trips correctly
- [x] Negative value (-1, encryption error) round-trips correctly
- [x] XML output includes `<EncryptionTimeMs>` element

Closes #11