### PR TITLE
fix: update coverage badge URL with actual Gist ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/tonyfgs/EasySave/actions/workflows/ci.yml/badge.svg)](https://github.com/tonyfgs/EasySave/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/tonyfgs/EasySave?include_prereleases&sort=semver)](https://github.com/tonyfgs/EasySave/releases)
-![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/tonyfgs/COVERAGE_GIST_ID/raw/coverage-badge.json)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/TheD57/ea906fd2258106e891f885e431fea712/raw/coverage-badge.json)
 
 ![C#](https://img.shields.io/badge/C%23-239120?style=for-the-badge&logo=c-sharp&logoColor=white)
 ![.NET](https://img.shields.io/badge/.NET-512BD4?style=for-the-badge&logo=dotnet&logoColor=white)


### PR DESCRIPTION
## Summary
- Replace placeholder `COVERAGE_GIST_ID` in README badge with actual Gist ID (`ea906fd2258106e891f885e431fea712`)
- Fix Gist owner from `tonyfgs` to `TheD57` (where the Gist was created)

This was missed in the CI/CD pipeline PR merge.