### PR TITLE
ci(hooks): enforce conventional commits with Husky.Net

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@commitlint/config-conventional"]
+}

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "husky": {
+      "version": "0.8.0",
+      "commands": [
+        "husky"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,18 @@
+name: Commit Lint
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: wagoid/commitlint-github-action@v6

--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,7 @@ PublishScripts/
 
 # Microsoft Azure Build Output
 csx/
+!.husky/csx/
 *.build.csdef
 
 # Microsoft Azure Emulator

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,22 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+## husky task runner examples -------------------
+## Note : for local installation use 'dotnet' prefix. e.g. 'dotnet husky'
+
+## run all tasks
+#husky run
+
+### run all tasks with group: 'group-name'
+#husky run --group group-name
+
+## run task with name: 'task-name'
+#husky run --name task-name
+
+## pass hook arguments to task
+#husky run --args "$1" "$2"
+
+## or put your custom commands -------------------
+#echo 'Husky.Net is awesome!'
+
+dotnet husky run --name "commit-message-linter" --args "$1"

--- a/.husky/csx/commit-lint.csx
+++ b/.husky/csx/commit-lint.csx
@@ -1,0 +1,35 @@
+/// <summary>
+/// Conventional Commits linter
+/// https://www.conventionalcommits.org/en/v1.0.0/
+/// </summary>
+
+using System.Text.RegularExpressions;
+
+private var pattern = @"^(?=.{1,90}$)(?:feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\([^)]+\))?!?(?::)\s.{3,}(?:#\d+)*(?<!\s)$";
+private var msg = File.ReadAllLines(Args[0])[0];
+
+// Bypass merge commits, squash merges, and reverts
+if (Regex.IsMatch(msg, @"^(Merge |Squash |Revert "")"))
+    return 0;
+
+if (Regex.IsMatch(msg, pattern))
+    return 0;
+
+Console.ForegroundColor = ConsoleColor.Red;
+Console.WriteLine("Invalid commit message format.");
+Console.ResetColor();
+Console.WriteLine();
+Console.WriteLine("Expected: <type>[optional scope][!]: <description>");
+Console.WriteLine();
+Console.WriteLine("  Valid types: feat fix docs style refactor perf test build ci chore revert");
+Console.WriteLine();
+Console.WriteLine("  Examples:");
+Console.WriteLine("    feat: add backup encryption");
+Console.WriteLine("    fix(model): handle null file path");
+Console.WriteLine("    feat!: breaking API change");
+Console.WriteLine();
+Console.ForegroundColor = ConsoleColor.Gray;
+Console.WriteLine("https://www.conventionalcommits.org/en/v1.0.0/");
+Console.ResetColor();
+
+return 1;

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,0 +1,10 @@
+{
+   "$schema": "https://alirezanet.github.io/Husky.Net/schema.json",
+   "tasks": [
+      {
+         "name": "commit-message-linter",
+         "command": "dotnet",
+         "args": ["husky", "exec", ".husky/csx/commit-lint.csx", "--args", "${args}"]
+      }
+   ]
+}

--- a/Console/Console.csproj
+++ b/Console/Console.csproj
@@ -1,26 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <RootNamespace>EasySave</RootNamespace>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <Content Include="..\.dockerignore">
-        <Link>.dockerignore</Link>
-      </Content>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
-      <ProjectReference Include="..\Application\Application.csproj" />
-      <ProjectReference Include="..\Model\Model.csproj" />
-      <ProjectReference Include="..\Shared\Shared.csproj" />
-      <ProjectReference Include="..\Logger\Logger.csproj" />
-    </ItemGroup>
-
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <RootNamespace>EasySave</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="..\.dockerignore">
+      <Link>.dockerignore</Link>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
+    <ProjectReference Include="..\Application\Application.csproj" />
+    <ProjectReference Include="..\Model\Model.csproj" />
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+    <ProjectReference Include="..\Logger\Logger.csproj" />
+  </ItemGroup>
+  <Target Name="Husky" BeforeTargets="Restore;CollectPackageReferences" Condition="'$(HUSKY)' != 0">
+    <Exec Command="dotnet tool restore" StandardOutputImportance="Low" StandardErrorImportance="High" />
+    <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High" WorkingDirectory=".." />
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
- Add **Husky.Net** as a local dotnet tool for local `commit-msg` hook validation with a C# linter script
- Add **wagoid/commitlint-github-action@v6** as CI safety net on PRs targeting `main`
- Auto-install hooks for all teammates via MSBuild target in `Console.csproj` (zero manual setup)

## Test plan
- [ ] `dotnet build` triggers `dotnet husky install` → hooks are active
- [ ] `git commit -m "bad"` → rejected with clear error
- [ ] `git commit -m "feat: valid message"` → accepted
- [ ] `git commit -m "fix(scope): scoped"` → accepted
- [ ] `git commit -m "feat!: breaking"` → accepted
- [ ] Merge/squash/revert commits bypass validation
- [ ] PR with non-compliant commits fails `Commit Lint` CI check