### PR TITLE
feat: implement cross-platform folder picker for Browse buttons

### DIFF
--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -48,19 +48,20 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4"/>
-        <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128"/>
-        <MauiImage Include="Resources\Images\*"/>
-        <MauiImage Update="Resources\Images\dotnet_bot.png" Resize="True" BaseSize="300,185"/>
-        <MauiFont Include="Resources\Fonts\*"/>
-        <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)"/>
+        <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
+        <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
+        <MauiImage Include="Resources\Images\*" />
+        <MauiImage Update="Resources\Images\dotnet_bot.png" Resize="True" BaseSize="300,185" />
+        <MauiFont Include="Resources\Fonts\*" />
+        <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="CommunityToolkit.Maui" Version="8.0.0" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
         <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.92" />
         <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.92" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/GUI/MauiProgram.cs
+++ b/GUI/MauiProgram.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using CommunityToolkit.Maui;
+using Microsoft.Extensions.Logging;
 
 namespace GUI;
 
@@ -9,6 +10,7 @@ public static class MauiProgram
         var builder = MauiApp.CreateBuilder();
         builder
             .UseMauiApp<App>()
+            .UseMauiCommunityToolkit()
             .ConfigureFonts(fonts =>
             {
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");

--- a/GUI/ViewModels/CreateJobViewModel.cs
+++ b/GUI/ViewModels/CreateJobViewModel.cs
@@ -174,18 +174,18 @@ public class CreateJobViewModel : ObservableObject
     /// </summary>
     private static async Task<string?> FolderPicker()
     {
-        await Task.CompletedTask;
         try
         {
-            // var result = await CommunityToolkit.Maui.Storage.FolderPicker.Default.PickAsync();
-            // if (result.IsSuccessful)
-            //     return result.Folder.Path;
-            Console.WriteLine("YO");
+            var result = await CommunityToolkit.Maui.Storage.FolderPicker.Default.PickAsync(CancellationToken.None);
+            if (result.IsSuccessful)
+                return result.Folder.Path;
         }
-        catch
+        catch (Exception ex)
         {
-            // FolderPicker may not be available on all platforms.
-            // User can type the path manually.
+            if (App.Current?.MainPage is not null)
+                await App.Current.MainPage.DisplayAlert("Error",
+                    $"Folder picker is not available on this platform. Please type the path manually.\n\n{ex.Message}",
+                    "OK");
         }
         return null;
     }


### PR DESCRIPTION
## Summary

- Added `CommunityToolkit.Maui` (v8.0.0) NuGet package for cross-platform storage APIs
- Registered `.UseMauiCommunityToolkit()` in the MAUI builder pipeline
- Replaced the stubbed `FolderPicker()` with the real `CommunityToolkit.Maui.Storage.FolderPicker` API that opens the native OS folder dialog (Finder on macOS, Explorer on Windows)
- Graceful fallback with `DisplayAlert` if the picker is unavailable on the platform

## Test plan

- [x] Build compiles with 0 errors / 0 warnings
- [x] Launch the app → Create Job form → click "Browse" for Source Path → native folder picker opens
- [x] Select a folder → path field populates with selected path
- [x] Repeat for Target Path
- [x] Cancel the picker → path field remains unchanged
- [x] Verify on macOS (Mac Catalyst) and Windows

Closes #59