### PR TITLE
fix: reject numeric input for backup type (#51)

### DIFF
--- a/Console/Commands/CreateJobCommand.cs
+++ b/Console/Commands/CreateJobCommand.cs
@@ -1,4 +1,5 @@
 using Application.Services;
+using EasySave.Utilities;
 using Model;
 
 namespace EasySave.Commands;
@@ -21,7 +22,7 @@ public class CreateJobCommand : ICommand
             var name = args[0];
             var source = args[1];
             var target = args[2];
-            var type = Enum.Parse<BackupType>(args[3], ignoreCase: true);
+            var type = BackupTypeParser.Parse(args[3]);
 
             var job = _jobService.CreateJob(name, source, target, type);
             _output.WriteLine($"Job '{job.Name}' created with ID {job.Id}.");

--- a/Console/Commands/ModifyJobCommand.cs
+++ b/Console/Commands/ModifyJobCommand.cs
@@ -1,4 +1,5 @@
 using Application.Services;
+using EasySave.Utilities;
 using Model;
 
 namespace EasySave.Commands;
@@ -22,7 +23,7 @@ public class ModifyJobCommand : ICommand
             var name = args[1];
             var source = args[2];
             var target = args[3];
-            var type = Enum.Parse<BackupType>(args[4], ignoreCase: true);
+            var type = BackupTypeParser.Parse(args[4]);
 
             _jobService.ModifyJob(id, name, source, target, type);
             _output.WriteLine($"Job {id} modified.");

--- a/Console/Utilities/BackupTypeParser.cs
+++ b/Console/Utilities/BackupTypeParser.cs
@@ -1,0 +1,11 @@
+using Model;
+
+namespace EasySave.Utilities;
+
+public static class BackupTypeParser
+{
+    public static BackupType Parse(string input)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Console/Utilities/BackupTypeParser.cs
+++ b/Console/Utilities/BackupTypeParser.cs
@@ -6,6 +6,14 @@ public static class BackupTypeParser
 {
     public static BackupType Parse(string input)
     {
-        throw new NotImplementedException();
+        if (string.IsNullOrWhiteSpace(input) || int.TryParse(input, out _))
+            throw new ArgumentException(
+                $"Invalid backup type: '{input}'. Expected 'Full' or 'Differential'.");
+
+        if (!Enum.TryParse<BackupType>(input, ignoreCase: true, out var result))
+            throw new ArgumentException(
+                $"Invalid backup type: '{input}'. Expected 'Full' or 'Differential'.");
+
+        return result;
     }
 }

--- a/Test/ConsoleTest/BackupTypeParserTests.cs
+++ b/Test/ConsoleTest/BackupTypeParserTests.cs
@@ -1,0 +1,42 @@
+using EasySave.Utilities;
+using Model;
+
+namespace ConsoleTest;
+
+public class BackupTypeParserTests
+{
+    [Theory]
+    [InlineData("Full", BackupType.Full)]
+    [InlineData("full", BackupType.Full)]
+    [InlineData("FULL", BackupType.Full)]
+    [InlineData("Differential", BackupType.Differential)]
+    [InlineData("differential", BackupType.Differential)]
+    [InlineData("DIFFERENTIAL", BackupType.Differential)]
+    public void Parse_ValidName_ShouldReturnBackupType(string input, BackupType expected)
+    {
+        var result = BackupTypeParser.Parse(input);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("1")]
+    [InlineData("2")]
+    [InlineData("-1")]
+    [InlineData("99")]
+    public void Parse_NumericString_ShouldThrowArgumentException(string input)
+    {
+        Assert.Throws<ArgumentException>(() => BackupTypeParser.Parse(input));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Incremental")]
+    [InlineData("abc")]
+    public void Parse_InvalidName_ShouldThrowArgumentException(string input)
+    {
+        Assert.Throws<ArgumentException>(() => BackupTypeParser.Parse(input));
+    }
+}

--- a/Test/ConsoleTest/ConsoleIntegrationTests.cs
+++ b/Test/ConsoleTest/ConsoleIntegrationTests.cs
@@ -85,6 +85,33 @@ public class ConsoleIntegrationTests
     }
 
     [Fact]
+    public void FullFlow_CreateJob_NumericBackupType_ShouldShowError()
+    {
+        var mockRepo = new Mock<IJobRepository>();
+        var jobService = new JobManagementService(mockRepo.Object);
+
+        var mockConfig = new Mock<ILanguageConfig>();
+        mockConfig.Setup(c => c.GetLanguage()).Returns(Language.EN);
+        var languageManager = CreateLanguageManager(mockConfig);
+        var inputParser = new InputParser();
+
+        var output = new StringWriter();
+        var commands = new Dictionary<string, ICommand>
+        {
+            ["1"] = new CreateJobCommand(jobService, output),
+            ["7"] = new ExitCommand()
+        };
+
+        var input = new StringReader("1\nTestBackup\n/source\n/target\n1\n7\n");
+        var ui = new ConsoleUI(languageManager, inputParser, commands, input, output);
+        ui.Run();
+
+        var text = output.ToString();
+        Assert.Contains("Invalid backup type", text);
+        mockRepo.Verify(r => r.Save(It.IsAny<BackupJob>()), Times.Never);
+    }
+
+    [Fact]
     public void FullFlow_DeleteJob_ShouldCallRepositoryDelete()
     {
         var mockRepo = new Mock<IJobRepository>();

--- a/Test/ConsoleTest/CreateJobCommandTests.cs
+++ b/Test/ConsoleTest/CreateJobCommandTests.cs
@@ -57,4 +57,29 @@ public class CreateJobCommandTests
 
         Assert.False(result.IsSuccess());
     }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("1")]
+    public void Execute_NumericBackupType_ShouldReturnFailure(string numericType)
+    {
+        var args = new List<string> { "MyBackup", "/src", "/dst", numericType };
+
+        var result = _command.Execute(args);
+
+        Assert.False(result.IsSuccess());
+    }
+
+    [Theory]
+    [InlineData("full")]
+    [InlineData("FULL")]
+    [InlineData("Full")]
+    public void Execute_CaseInsensitiveBackupType_ShouldReturnSuccess(string type)
+    {
+        var args = new List<string> { "MyBackup", "/src", "/dst", type };
+
+        var result = _command.Execute(args);
+
+        Assert.True(result.IsSuccess());
+    }
 }

--- a/Test/ConsoleTest/ModifyJobCommandTests.cs
+++ b/Test/ConsoleTest/ModifyJobCommandTests.cs
@@ -61,4 +61,32 @@ public class ModifyJobCommandTests
 
         Assert.False(result.IsSuccess());
     }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("1")]
+    public void Execute_NumericBackupType_ShouldReturnFailure(string numericType)
+    {
+        var args = new List<string> { "1", "NewJob", "/src", "/dst", numericType };
+
+        var result = _command.Execute(args);
+
+        Assert.False(result.IsSuccess());
+    }
+
+    [Theory]
+    [InlineData("differential")]
+    [InlineData("DIFFERENTIAL")]
+    [InlineData("Differential")]
+    public void Execute_CaseInsensitiveBackupType_ShouldReturnSuccess(string type)
+    {
+        var existingJob = new BackupJob(1, "OldJob", "/old/src", "/old/dst", BackupType.Full);
+        _mockRepo.Setup(r => r.GetById(1)).Returns(existingJob);
+
+        var args = new List<string> { "1", "NewJob", "/new/src", "/new/dst", type };
+
+        var result = _command.Execute(args);
+
+        Assert.True(result.IsSuccess());
+    }
 }


### PR DESCRIPTION
## Summary
- Add `BackupTypeParser.Parse()` utility that rejects numeric strings (`"0"`, `"1"`, `"2"`, etc.) and only accepts named values (`"Full"`, `"Differential"`, case-insensitive)
- Replace `Enum.Parse<BackupType>()` with `BackupTypeParser.Parse()` in `CreateJobCommand` and `ModifyJobCommand`
- Add 26 new tests (15 parser unit tests, 10 command regression tests, 1 integration test)

## Test plan
- [x] `dotnet test` — 391 tests pass (0 failures)
- [x] Manual: enter `1` as backup type → error: `Invalid backup type: '1'. Expected 'Full' or 'Differential'.`
- [x] Manual: enter `Full`, `full`, `FULL` → accepted
- [x] Manual: enter `Differential`, `differential` → accepted

Closes #51