### PR TITLE
feat: implement ProcessDetector (Infrastructure)

### DIFF
--- a/Infrastructure/ProcessDetector.cs
+++ b/Infrastructure/ProcessDetector.cs
@@ -24,7 +24,10 @@ public class ProcessDetector : IBusinessSoftwareDetector
         try
         {
             var processes = FindProcesses(name);
-            return processes.Length > 0
+            var isRunning = processes.Length > 0;
+            foreach (var process in processes)
+                process.Dispose();
+            return isRunning
                 ? BusinessSoftwareStatus.Running
                 : BusinessSoftwareStatus.NotRunning;
         }

--- a/Infrastructure/ProcessDetector.cs
+++ b/Infrastructure/ProcessDetector.cs
@@ -14,7 +14,24 @@ public class ProcessDetector : IBusinessSoftwareDetector
 
     public BusinessSoftwareStatus GetStatus()
     {
-        return BusinessSoftwareStatus.Disabled;
+        if (!_config.IsDetectionEnabled())
+            return BusinessSoftwareStatus.Disabled;
+
+        var name = _config.GetBusinessSoftwareName();
+        if (string.IsNullOrWhiteSpace(name))
+            return BusinessSoftwareStatus.Disabled;
+
+        try
+        {
+            var processes = FindProcesses(name);
+            return processes.Length > 0
+                ? BusinessSoftwareStatus.Running
+                : BusinessSoftwareStatus.NotRunning;
+        }
+        catch
+        {
+            return BusinessSoftwareStatus.Error;
+        }
     }
 
     protected virtual Process[] FindProcesses(string name)

--- a/Infrastructure/ProcessDetector.cs
+++ b/Infrastructure/ProcessDetector.cs
@@ -1,0 +1,24 @@
+using System.Diagnostics;
+using Application.Ports;
+
+namespace Infrastructure;
+
+public class ProcessDetector : IBusinessSoftwareDetector
+{
+    private readonly IBusinessSoftwareConfig _config;
+
+    public ProcessDetector(IBusinessSoftwareConfig config)
+    {
+        _config = config ?? throw new ArgumentNullException(nameof(config));
+    }
+
+    public BusinessSoftwareStatus GetStatus()
+    {
+        return BusinessSoftwareStatus.Disabled;
+    }
+
+    protected virtual Process[] FindProcesses(string name)
+    {
+        return Process.GetProcessesByName(name);
+    }
+}

--- a/Test/InfrastructureTest/ProcessDetectorTests.cs
+++ b/Test/InfrastructureTest/ProcessDetectorTests.cs
@@ -1,0 +1,82 @@
+using Application.Ports;
+using Infrastructure;
+using Moq;
+
+namespace InfrastructureTest;
+
+public class ProcessDetectorTests
+{
+    private readonly Mock<IBusinessSoftwareConfig> _configMock;
+
+    public ProcessDetectorTests()
+    {
+        _configMock = new Mock<IBusinessSoftwareConfig>();
+    }
+
+    [Fact]
+    public void GetStatus_WhenDetectionDisabled_ReturnsDisabled()
+    {
+        _configMock.Setup(c => c.IsDetectionEnabled()).Returns(false);
+        var detector = new ProcessDetector(_configMock.Object);
+
+        var result = detector.GetStatus();
+
+        Assert.Equal(BusinessSoftwareStatus.Disabled, result);
+    }
+
+    [Fact]
+    public void GetStatus_WhenNameEmpty_ReturnsDisabled()
+    {
+        _configMock.Setup(c => c.IsDetectionEnabled()).Returns(true);
+        _configMock.Setup(c => c.GetBusinessSoftwareName()).Returns("");
+        var detector = new ProcessDetector(_configMock.Object);
+
+        var result = detector.GetStatus();
+
+        Assert.Equal(BusinessSoftwareStatus.Disabled, result);
+    }
+
+    [Fact]
+    public void GetStatus_WhenProcessNotFound_ReturnsNotRunning()
+    {
+        _configMock.Setup(c => c.IsDetectionEnabled()).Returns(true);
+        _configMock.Setup(c => c.GetBusinessSoftwareName()).Returns("nonexistent_process_xyz_12345");
+        var detector = new ProcessDetector(_configMock.Object);
+
+        var result = detector.GetStatus();
+
+        Assert.Equal(BusinessSoftwareStatus.NotRunning, result);
+    }
+
+    [Fact]
+    public void GetStatus_WhenProcessExists_ReturnsRunning()
+    {
+        _configMock.Setup(c => c.IsDetectionEnabled()).Returns(true);
+        _configMock.Setup(c => c.GetBusinessSoftwareName()).Returns("dotnet");
+        var detector = new ProcessDetector(_configMock.Object);
+
+        var result = detector.GetStatus();
+
+        Assert.Equal(BusinessSoftwareStatus.Running, result);
+    }
+
+    [Fact]
+    public void GetStatus_WhenExceptionOccurs_ReturnsError()
+    {
+        _configMock.Setup(c => c.IsDetectionEnabled()).Returns(true);
+        _configMock.Setup(c => c.GetBusinessSoftwareName()).Returns("anything");
+        var detector = new ThrowingProcessDetector(_configMock.Object);
+
+        var result = detector.GetStatus();
+
+        Assert.Equal(BusinessSoftwareStatus.Error, result);
+    }
+
+    private class ThrowingProcessDetector : ProcessDetector
+    {
+        public ThrowingProcessDetector(IBusinessSoftwareConfig config) : base(config) { }
+
+        protected override System.Diagnostics.Process[] FindProcesses(string name) =>
+            throw new InvalidOperationException("simulated process error");
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `ProcessDetector : IBusinessSoftwareDetector` that uses `Process.GetProcessesByName()` to detect running business software
- Constructor receives `IBusinessSoftwareConfig` for detection toggle and process name
- `GetStatus()` returns `BusinessSoftwareStatus` (Disabled / NotRunning / Running / Error)
- Properly disposes `Process[]` results to prevent OS handle leaks

## TDD Commits
1. **RED**: 5 tests + stub — 3 failing
2. **GREEN**: full `GetStatus()` implementation — 5/5 pass
3. **REFACTOR**: dispose `Process[]` handles

## Test plan
- [x] Detection disabled → `Disabled`
- [x] Empty process name → `Disabled`
- [x] Nonexistent process → `NotRunning`
- [x] Running process (`dotnet`) → `Running`
- [x] Exception → `Error` (no propagation)
- [x] Full test suite: 409 tests, 0 failures

Closes #22