### PR TITLE
fix: break instead of continue in pre-flight detection (#24)

### DIFF
--- a/Application/Services/BackupExecutionService.cs
+++ b/Application/Services/BackupExecutionService.cs
@@ -58,7 +58,7 @@ public class BackupExecutionService
                         new List<string> { $"Business software detected ({status})" },
                         TimeSpan.Zero);
                     results.Add(new JobExecutionResult(jobId, failResult));
-                    continue;
+                    break;
                 }
             }
 

--- a/Test/ApplicationTest/BackupExecutionServiceTests.cs
+++ b/Test/ApplicationTest/BackupExecutionServiceTests.cs
@@ -191,4 +191,24 @@ public class BackupExecutionServiceTests
         Assert.Single(results);
         Assert.False(results[0].Result.Success);
     }
+
+    [Fact]
+    public void ExecuteJobs_DetectionEnabled_Running_ShouldNotProcessRemainingJobs()
+    {
+        var job1 = new BackupJob(1, "Job1", "/src1", "/dst1", BackupType.Full);
+        var job2 = new BackupJob(2, "Job2", "/src2", "/dst2", BackupType.Full);
+        var job3 = new BackupJob(3, "Job3", "/src3", "/dst3", BackupType.Full);
+        _mockRepo.Setup(r => r.GetById(1)).Returns(job1);
+        _mockRepo.Setup(r => r.GetById(2)).Returns(job2);
+        _mockRepo.Setup(r => r.GetById(3)).Returns(job3);
+        _mockDetectorConfig.Setup(c => c.IsDetectionEnabled()).Returns(true);
+        _mockDetector.Setup(d => d.GetStatus()).Returns(BusinessSoftwareStatus.Running);
+
+        var results = _service.ExecuteJobs(new List<int> { 1, 2, 3 });
+
+        Assert.Single(results);
+        Assert.Equal(1, results[0].JobId);
+        Assert.False(results[0].Result.Success);
+        Assert.Contains(results[0].Result.Errors, e => e.Contains("Business software"));
+    }
 }


### PR DESCRIPTION
## Summary
- Fix `continue` → `break` in `BackupExecutionService.ExecuteJobs()` so remaining jobs in the batch are skipped when business software is detected (spec requirement)
- Add missing multi-job test `ExecuteJobs_DetectionEnabled_Running_ShouldNotProcessRemainingJobs`

## Test plan
- [x] 149 tests pass, 0 failures
- [x] New test verifies batch [1,2,3] with detection Running → only 1 result (jobs 2,3 not attempted)

Closes #24