### PR TITLE
ci: add GUI MAUI builds to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,66 @@ jobs:
           name: EasySave-${{ matrix.runtime }}
           path: EasySave-${{ steps.version.outputs.version }}-${{ matrix.runtime }}.*
 
+  build-gui:
+    needs: validate
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            framework: net8.0-windows10.0.19041.0
+            artifact: EasySave-GUI-win-x64
+            archive: zip
+          - os: macos-latest
+            framework: net8.0-maccatalyst
+            artifact: EasySave-GUI-osx-arm64
+            archive: zip
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Install MAUI workload
+        run: dotnet workload install maui
+
+      - name: Extract version from tag
+        id: version
+        shell: bash
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: echo "version=${TAG_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish GUI
+        run: >
+          dotnet publish GUI/GUI.csproj
+          -f ${{ matrix.framework }}
+          --configuration Release
+          -p:Version=${{ steps.version.outputs.version }}
+          -o ./publish-gui
+
+      - name: Archive (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          cd publish-gui
+          7z a ../${{ matrix.artifact }}-${{ steps.version.outputs.version }}.zip .
+
+      - name: Archive (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          cd publish-gui
+          zip -r ../${{ matrix.artifact }}-${{ steps.version.outputs.version }}.zip .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}-${{ steps.version.outputs.version }}.zip
+
   build-docker:
     needs: validate
     runs-on: ubuntu-latest
@@ -130,7 +190,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   create-release:
-    needs: [build-binaries, build-docker]
+    needs: [build-binaries, build-gui, build-docker]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

- Add `build-gui` job to release workflow: builds MAUI GUI for Windows (win-x64) and macOS (maccatalyst-arm64)
- GUI artifacts are zipped and included in the GitHub Release alongside Console binaries
- Also includes previous CI fixes (NoGUI solution filter for coverage badge, --no-restore drop for Windows)

## Test plan

- [ ] CI passes
- [ ] After merge: tag `v2.0.1-rc1` to test release with GUI builds (pre-release)